### PR TITLE
Fix URL linkification for truncated post text

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -254,9 +254,35 @@ $(document).ready(function () {
 	}
 
 	function applyPostProcessing() {
-		$('.post-text').linkify({
-			target: "_blank",
-			className: 'lien text-lighten-2'
+		$('.post-text').each(function() {
+			const $el = $(this);
+			if ($el.data('linkified')) return;
+			$el.data('linkified', true);
+
+			const fullText = $el.data('full-text');
+			const isDisplayTruncated = fullText && $el.text() !== fullText;
+
+			if (isDisplayTruncated) {
+				// Linkify the full text in a temporary element to extract complete URLs
+				const $temp = $('<span>').text(fullText);
+				$temp.linkify({ target: '_blank', className: 'lien text-lighten-2' });
+				const fullUrls = [];
+				$temp.find('.lien').each(function() {
+					fullUrls.push($(this).attr('href'));
+				});
+
+				// Linkify the truncated display text
+				$el.linkify({ target: '_blank', className: 'lien text-lighten-2' });
+
+				// Replace truncated hrefs with the complete URLs from the full text
+				$el.find('.lien').each(function(i) {
+					if (i < fullUrls.length) {
+						$(this).attr('href', fullUrls[i]);
+					}
+				});
+			} else {
+				$el.linkify({ target: '_blank', className: 'lien text-lighten-2' });
+			}
 		});
 		updateLoadedCount();
 	}


### PR DESCRIPTION
## Summary
Improved the post text linkification logic to correctly handle truncated content by ensuring that links in truncated text point to the complete URLs from the full text, rather than potentially incomplete or incorrect URLs.

## Key Changes
- Modified `applyPostProcessing()` to iterate through each post element individually instead of applying linkification globally
- Added a deduplication check using `data('linkified')` to prevent processing the same element multiple times
- Implemented special handling for truncated text:
  - Detects when displayed text is truncated by comparing it against the full text stored in `data('full-text')`
  - For truncated content, linkifies the full text in a temporary element to extract complete URLs
  - Applies linkification to the truncated display text, then replaces the href attributes with the correct complete URLs from the full text
  - For non-truncated content, applies standard linkification
- Maintained existing link styling (target="_blank", className='lien text-lighten-2')

## Implementation Details
The fix addresses a scenario where truncated post text (e.g., "Check out this link...") would be linkified based on the truncated content alone, potentially creating incorrect or incomplete URLs. By comparing against the full text and extracting URLs from there, the links now correctly point to the intended destinations even when the display text is shortened.

https://claude.ai/code/session_0123WUCuLmTyb2JAc4k5wnNg